### PR TITLE
Migrate coverage badge from Coveralls to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/latte/actions"><img src="https://badgen.net/github/checks/contributte/latte/master?cache=300"></a>
-  <a href="https://coveralls.io/r/contributte/latte"><img src="https://badgen.net/coveralls/c/github/contributte/latte?cache=300"></a>
+  <a href="https://codecov.io/gh/contributte/latte"><img src="https://badgen.net/codecov/c/github/contributte/latte"></a>
   <a href="https://packagist.org/packages/contributte/latte"><img src="https://badgen.net/packagist/dm/contributte/latte"></a>
   <a href="https://packagist.org/packages/contributte/latte"><img src="https://badgen.net/packagist/v/contributte/latte"></a>
 </p>


### PR DESCRIPTION
## What changed
- replaced the README coverage badge link and image with the Codecov variant used in `contributte/vite`
- verified the repository already uses the shared `nette-tester-coverage-v2` workflow, so no workflow wiring changes were needed

## Why
- completes the remaining Coveralls-to-Codecov cleanup for `contributte/latte`
- keeps the coverage badge aligned with the current reporting service and the migration tracked in contributte/contributte#72