### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ tests:
 
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Run the Makefile coverage target with `php` instead of `phpdbg` so this repository matches the org-wide coverage migration in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from coverage targets across Contributte. This keeps `contributte/latte` aligned with that migration and avoids relying on PHPDBG for coverage runs.

## Changes

- replace `-p phpdbg` with `-p php` in both `coverage` target variants in `Makefile`

## Testing

- [x] Attempted `make coverage`
- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification not applicable

`make coverage` currently fails in this environment because PHP is running without Xdebug, PCOV, or PHPDBG, so code coverage cannot start with pure `php`.